### PR TITLE
FIX: bad naming

### DIFF
--- a/hxntools/detectors/xspress3.py
+++ b/hxntools/detectors/xspress3.py
@@ -211,7 +211,7 @@ class Xspress3FileStore(FileStorePluginBase, HDF5Plugin):
 
         logger.debug('Inserting the filestore resource: %s', self._fn)
         fn = PurePath(self._fn).relative_to(self.fs_root)
-        self._resource = self._fs.insert_resource(
+        self._filestore_res = self._fs.insert_resource(
             Xspress3HDF5Handler.HANDLER_NAME, str(fn), {},
             root=str(self.fs_root))
 


### PR DESCRIPTION
Unlike all of the other devices in HXN tools, the xspress3 uses
`self._filestore_res` rather that `self._resource` to hold the
resource uid.  There was a bay copy-paste-not-read job in
b773900831bd88f73aa49dda9192278335e1cb1a 🐑.  The initial
value (`None`) was being inserted into the datum documents