### PR TITLE
Fix custom plans based on `relative_inner_product_scan`

### DIFF
--- a/hxntools/detectors/trigger_mixins.py
+++ b/hxntools/detectors/trigger_mixins.py
@@ -172,19 +172,14 @@ class FileStoreBulkReadable(FileStoreIterativeWrite):
 
     def bulk_read(self, timestamps):
         image_name = self.image_name
-        print("Bulk_read start", ttime.time())
         #uids = [self.generate_datum(self.image_name, ts, {}) for ts in timestamps]
-
         uids = []
         for i, ts in enumerate(timestamps):
             print(i, ttime.time())
             uids.append(self.generate_datum(self.image_name, ts, {}))
 
-        print("Bulk_read middle", ttime.time())
-
         # clear so unstage will not save the images twice:
         self._reset_data()
-        print("Bulk_read end", ttime.time())
         return {image_name: uids}
 
     @property

--- a/hxntools/detectors/trigger_mixins.py
+++ b/hxntools/detectors/trigger_mixins.py
@@ -172,11 +172,19 @@ class FileStoreBulkReadable(FileStoreIterativeWrite):
 
     def bulk_read(self, timestamps):
         image_name = self.image_name
+        print("Bulk_read start", ttime.time())
+        #uids = [self.generate_datum(self.image_name, ts, {}) for ts in timestamps]
 
-        uids = [self.generate_datum(self.image_name, ts, {}) for ts in timestamps]
+        uids = []
+        for i, ts in enumerate(timestamps):
+            print(i, ttime.time())
+            uids.append(self.generate_datum(self.image_name, ts, {}))
+
+        print("Bulk_read middle", ttime.time())
 
         # clear so unstage will not save the images twice:
         self._reset_data()
+        print("Bulk_read end", ttime.time())
         return {image_name: uids}
 
     @property

--- a/hxntools/detectors/trigger_mixins.py
+++ b/hxntools/detectors/trigger_mixins.py
@@ -175,7 +175,6 @@ class FileStoreBulkReadable(FileStoreIterativeWrite):
         #uids = [self.generate_datum(self.image_name, ts, {}) for ts in timestamps]
         uids = []
         for i, ts in enumerate(timestamps):
-            print(i, ttime.time())
             uids.append(self.generate_datum(self.image_name, ts, {}))
 
         # clear so unstage will not save the images twice:

--- a/hxntools/scans.py
+++ b/hxntools/scans.py
@@ -258,7 +258,7 @@ def _get_a2_args(*args, time=None):
 @functools.wraps(plans.inner_product_scan)
 def a2scan(dets, *args, time=None, md=None):
     args, time = _get_a2_args(*args, time=time)
-    total_points = int(args[-1])
+    total_points = int(args[0])
     yield from _pre_scan(dets, total_points=total_points, count_time=time)
     return (yield from plans.inner_product_scan(dets, *args, md=md,
                                                 per_step=one_nd_step))
@@ -267,7 +267,7 @@ def a2scan(dets, *args, time=None, md=None):
 @functools.wraps(plans.relative_inner_product_scan)
 def d2scan(dets, *args, time=None, md=None):
     args, time = _get_a2_args(*args, time=time)
-    total_points = int(args[-1])
+    total_points = int(args[0])
     yield from _pre_scan(dets, total_points=total_points, count_time=time)
     return (yield from plans.relative_inner_product_scan(dets, *args, md=md,
                                                          per_step=one_nd_step))


### PR DESCRIPTION
Fix for `d2scan` and `a2scan` that are based on `relative_inner_product_scan`.