### PR TITLE
Allow registration of custom Xspres3HDF5Handler (HXN)

### DIFF
--- a/hxntools/handlers/xspress3.py
+++ b/hxntools/handlers/xspress3.py
@@ -14,4 +14,4 @@ FMT_ROI_KEY = 'entry/instrument/detector/NDAttributes/CHAN{}ROI{}'
 
 def register(db):
     db.reg.register_handler(Xspress3HDF5Handler.HANDLER_NAME,
-                            Xspress3HDF5Handler)
+                            Xspress3HDF5Handler, overwrite=True)


### PR DESCRIPTION
This is a temporary fix to make Ptycho work